### PR TITLE
Rmb toggles movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # factoriomousecontrol
 
 This script lets you control the character of factorio with your mouse.
-If the the right mouse button is pressed, the character will run towards the mouse (limited to 8 directions due to factorio) unless the mouse is in the center of screen deadzone (currently 15%, variable in the script).
+If the the right mouse button is clicked, the character will run towards the mouse (limited to 8 directions due to factorio) unless the mouse is in the center of screen deadzone (currently 20%, variable in the script). Clicking again, or pressing any button on the keyboard, will stop movement. 
 
 
 ## Installation
-- Install autohotkey (www.autohotkey.com)
+- Install autohotkey (www.autohotkey.com v1)
 - Run factorio.ahk
 - Have Fun

--- a/factorio.ahk
+++ b/factorio.ahk
@@ -8,107 +8,91 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 #MaxThreads 2
 #MaxThreadsPerHotkey 2
 
-deadzone := 0.20
+deadzone := 0.15
+
+
 toggle := 0
 
-InterruptToggle:
-{
-  ifWinActive, Factorio
-  {
-    toggle := 0
-    GoSub, Run
-  }
+	
+Run:	
+{	
+	ifWinActive, Factorio
+	{
+		MouseGetPos, x,y 
+		WinGetPos , , , width, height
+		WinGetClass, class, A
+		;MsgBox, %class%
+		halfw := width/2
+		halfh := height/2
+		;FileAppend, %class% po: %y% w: %halfh%`n, ahklog.txt
+		if (x > halfw * (1+deadzone))
+		{
+			if(toggle)
+			{
+				Send, {d down}
+			}
+			else
+			{
+				send, {d up}
+			}
+		} 
+		else
+		{
+			send, {d up}
+		}
+		if (y < halfh*(1-deadzone))
+		{
+			if(toggle)
+			{
+				Send, {w down}
+			}
+			else
+			{
+				send, {w up}
+			}		
+		} 	
+		else
+		{
+			send, {w up}
+		}
+		if (x < halfw * (1-deadzone))
+		{
+			if(toggle)
+			{
+				Send, {a down}
+			}
+			else
+			{
+				send, {a up}
+			}		
+		} 
+		else
+		{
+			send, {a up}
+		}
+		if (y > halfh*(1+deadzone))
+		{
+			if(toggle)
+			{
+				Send, {s down}
+			}
+			else
+			{
+				send, {s up}
+			}		
+		} 	
+		else
+		{
+			send, {s up}
+		}
+	}
 }
-  
-Run:  
-{  
-  ifWinActive, Factorio
-  {
-    MouseGetPos, x,y 
-    WinGetPos , , , width, height
-    WinGetClass, class, A
-    ;MsgBox, %class%
-    halfw := width/2
-    halfh := height/2
-    ;FileAppend, %class% po: %y% w: %halfh%`n, ahklog.txt
-    if (x > halfw * (1+deadzone))
-    {
-      if(toggle)
-      {
-        Send, {d down}
-      }
-      else
-      {
-        send, {d up}
-      }
-    } 
-    else
-    {
-      send, {d up}
-    }
-    if (y < halfh*(1-deadzone))
-    {
-      if(toggle)
-      {
-        Send, {w down}
-      }
-      else
-      {
-        send, {w up}
-      }    
-    }   
-    else
-    {
-      send, {w up}
-    }
-    if (x < halfw * (1-deadzone))
-    {
-      if(toggle)
-      {
-        Send, {a down}
-      }
-      else
-      {
-        send, {a up}
-      }    
-    } 
-    else
-    {
-      send, {a up}
-    }
-    if (y > halfh*(1+deadzone))
-    {
-      if(toggle)
-      {
-        Send, {s down}
-      }
-      else
-      {
-        send, {s up}
-      }    
-    }   
-    else
-    {
-      send, {s up}
-    }
-  }
-}
-
-Hotkey, IfWinActive, Factorio ; now, the following Hotkey calls only apply to Factorio
-keyboard_characters = 0123456789abcdefghijklmnopqrstuvwxyz
-loop, parse, keyboard_characters ; for every keyboard character
-{
-    Hotkey, ~%A_LoopField%, InterruptToggle ; pressing a key interrupts movement and functions normally (e.g., `e` still brings up the dialog box)
-}
-
-#ifWinActive, Factorio
-~Esc::GoSub, InterruptToggle
 
 #ifWinActive, Factorio
 ~RButton Up::
-  toggle := !toggle
-  ; state := GetKeyState("RButton", "D")
-  ; FileAppend, class: %class% state: %state%`n, ahklog.txt
+	toggle := !toggle
+	state := GetKeyState("RButton", "D")
+	; FileAppend, class: %class% state: %state%`n, ahklog.txt
   if (toggle)
   {
     while toggle
@@ -121,5 +105,5 @@ loop, parse, keyboard_characters ; for every keyboard character
   {
     GoSub, Run
   }
-  ; FileAppend, finished`n, ahklog.txt
-  return
+	; FileAppend, finished`n, ahklog.txt
+	return

--- a/factorio.ahk
+++ b/factorio.ahk
@@ -1,17 +1,22 @@
+#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+#Warn  ; Enable warnings to assist with detecting common errors.
+SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
+SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
+
+
 #Persistent
 #MaxThreads 2
+#MaxThreadsPerHotkey 2
 
 deadzone := 0.15
 
 
 toggle := 0
 
-
-;SetTimer, Run, 50
 	
 Run:	
 {	
-	if WinActive("ahk_class ALEX")
+	ifWinActive, Factorio
 	{
 		MouseGetPos, x,y 
 		WinGetPos , , , width, height
@@ -19,7 +24,7 @@ Run:
 		;MsgBox, %class%
 		halfw := width/2
 		halfh := height/2
-		;FileAppend, %class% po: %y% w: %halfh%`n, D:\ahklog.txt
+		;FileAppend, %class% po: %y% w: %halfh%`n, ahklog.txt
 		if (x > halfw * (1+deadzone))
 		{
 			if(toggle)
@@ -81,26 +86,24 @@ Run:
 			send, {s up}
 		}
 	}
-	;sleep 1000
 }
 
-#IfWinActive, ahk_class ALEX
-~RButton::
-	toggle := true
-	state := GetKeyState("RButton", "D") 
-	;FileAppend, down: %class% state: %state%`n, D:\ahklog.txt
-	while GetKeyState("RButton", "D") && toggle
-	{
-		GoSub, Run
-		sleep, 30
-	}
-	;FileAppend, down finished`n, D:\ahklog.txt
-	return
-#IfWinActive, ahk_class ALEX	
+#ifWinActive, Factorio
 ~RButton Up::
-	toggle := false
-	state := GetKeyState("RButton", "D") 
-	;FileAppend, up:  %class% state: %state%`n, D:\ahklog.txt
-	GoSub, Run
+	toggle := !toggle
+	state := GetKeyState("RButton", "D")
+	; FileAppend, class: %class% state: %state%`n, ahklog.txt
+  if (toggle)
+  {
+    while toggle
+    {
+      GoSub, Run
+      sleep, 100
+    }
+  }
+  else
+  {
+    GoSub, Run
+  }
+	; FileAppend, finished`n, ahklog.txt
 	return
-

--- a/factorio.ahk
+++ b/factorio.ahk
@@ -8,91 +8,107 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 #MaxThreads 2
 #MaxThreadsPerHotkey 2
 
-deadzone := 0.15
-
-
+deadzone := 0.20
 toggle := 0
 
-	
-Run:	
-{	
-	ifWinActive, Factorio
-	{
-		MouseGetPos, x,y 
-		WinGetPos , , , width, height
-		WinGetClass, class, A
-		;MsgBox, %class%
-		halfw := width/2
-		halfh := height/2
-		;FileAppend, %class% po: %y% w: %halfh%`n, ahklog.txt
-		if (x > halfw * (1+deadzone))
-		{
-			if(toggle)
-			{
-				Send, {d down}
-			}
-			else
-			{
-				send, {d up}
-			}
-		} 
-		else
-		{
-			send, {d up}
-		}
-		if (y < halfh*(1-deadzone))
-		{
-			if(toggle)
-			{
-				Send, {w down}
-			}
-			else
-			{
-				send, {w up}
-			}		
-		} 	
-		else
-		{
-			send, {w up}
-		}
-		if (x < halfw * (1-deadzone))
-		{
-			if(toggle)
-			{
-				Send, {a down}
-			}
-			else
-			{
-				send, {a up}
-			}		
-		} 
-		else
-		{
-			send, {a up}
-		}
-		if (y > halfh*(1+deadzone))
-		{
-			if(toggle)
-			{
-				Send, {s down}
-			}
-			else
-			{
-				send, {s up}
-			}		
-		} 	
-		else
-		{
-			send, {s up}
-		}
-	}
+InterruptToggle:
+{
+  ifWinActive, Factorio
+  {
+    toggle := 0
+    GoSub, Run
+  }
+}
+  
+Run:  
+{  
+  ifWinActive, Factorio
+  {
+    MouseGetPos, x,y 
+    WinGetPos , , , width, height
+    WinGetClass, class, A
+    ;MsgBox, %class%
+    halfw := width/2
+    halfh := height/2
+    ;FileAppend, %class% po: %y% w: %halfh%`n, ahklog.txt
+    if (x > halfw * (1+deadzone))
+    {
+      if(toggle)
+      {
+        Send, {d down}
+      }
+      else
+      {
+        send, {d up}
+      }
+    } 
+    else
+    {
+      send, {d up}
+    }
+    if (y < halfh*(1-deadzone))
+    {
+      if(toggle)
+      {
+        Send, {w down}
+      }
+      else
+      {
+        send, {w up}
+      }    
+    }   
+    else
+    {
+      send, {w up}
+    }
+    if (x < halfw * (1-deadzone))
+    {
+      if(toggle)
+      {
+        Send, {a down}
+      }
+      else
+      {
+        send, {a up}
+      }    
+    } 
+    else
+    {
+      send, {a up}
+    }
+    if (y > halfh*(1+deadzone))
+    {
+      if(toggle)
+      {
+        Send, {s down}
+      }
+      else
+      {
+        send, {s up}
+      }    
+    }   
+    else
+    {
+      send, {s up}
+    }
+  }
+}
+
+Hotkey, IfWinActive, Factorio ; now, the following Hotkey calls only apply to Factorio
+keyboard_characters = 0123456789abcdefghijklmnopqrstuvwxyz
+loop, parse, keyboard_characters ; for every keyboard character
+{
+    Hotkey, ~%A_LoopField%, InterruptToggle ; pressing a key interrupts movement and functions normally (e.g., `e` still brings up the dialog box)
 }
 
 #ifWinActive, Factorio
+~Esc::GoSub, InterruptToggle
+
+#ifWinActive, Factorio
 ~RButton Up::
-	toggle := !toggle
-	state := GetKeyState("RButton", "D")
-	; FileAppend, class: %class% state: %state%`n, ahklog.txt
+  toggle := !toggle
+  ; state := GetKeyState("RButton", "D")
+  ; FileAppend, class: %class% state: %state%`n, ahklog.txt
   if (toggle)
   {
     while toggle
@@ -105,5 +121,5 @@ Run:
   {
     GoSub, Run
   }
-	; FileAppend, finished`n, ahklog.txt
-	return
+  ; FileAppend, finished`n, ahklog.txt
+  return

--- a/factorio.ahk
+++ b/factorio.ahk
@@ -1,8 +1,7 @@
-#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
-#Warn  ; Enable warnings to assist with detecting common errors.
-SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
-SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
-
+#NoEnv ; Recommended for performance and compatibility with future AutoHotkey releases.
+#Warn ; Enable warnings to assist with detecting common errors.
+SendMode Input ; Recommended for new scripts due to its superior speed and reliability.
+SetWorkingDir %A_ScriptDir% ; Ensures a consistent starting directory.
 
 #Persistent
 #MaxThreads 2
@@ -10,100 +9,102 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 
 deadzone := 0.15
 
-
 toggle := 0
 
-	
 Run:	
-{	
-	ifWinActive, Factorio
-	{
-		MouseGetPos, x,y 
-		WinGetPos , , , width, height
-		WinGetClass, class, A
-		;MsgBox, %class%
-		halfw := width/2
-		halfh := height/2
-		;FileAppend, %class% po: %y% w: %halfh%`n, ahklog.txt
-		if (x > halfw * (1+deadzone))
-		{
-			if(toggle)
-			{
-				Send, {d down}
-			}
-			else
-			{
-				send, {d up}
-			}
-		} 
-		else
-		{
-			send, {d up}
-		}
-		if (y < halfh*(1-deadzone))
-		{
-			if(toggle)
-			{
-				Send, {w down}
-			}
-			else
-			{
-				send, {w up}
-			}		
-		} 	
-		else
-		{
-			send, {w up}
-		}
-		if (x < halfw * (1-deadzone))
-		{
-			if(toggle)
-			{
-				Send, {a down}
-			}
-			else
-			{
-				send, {a up}
-			}		
-		} 
-		else
-		{
-			send, {a up}
-		}
-		if (y > halfh*(1+deadzone))
-		{
-			if(toggle)
-			{
-				Send, {s down}
-			}
-			else
-			{
-				send, {s up}
-			}		
-		} 	
-		else
-		{
-			send, {s up}
-		}
-	}
-}
-
-#ifWinActive, Factorio
-~RButton Up::
-	toggle := !toggle
-	state := GetKeyState("RButton", "D")
-	; FileAppend, class: %class% state: %state%`n, ahklog.txt
-  if (toggle)
-  {
-    while toggle
-    {
-      GoSub, Run
-      sleep, 100
+    {	
+        ifWinActive, Factorio
+        {
+            MouseGetPos, x,y 
+            WinGetPos , , , width, height
+            WinGetClass, class, A
+            ;MsgBox, %class%
+            halfw := width/2
+            halfh := height/2
+            ;FileAppend, %class% po: %y% w: %halfh%`n, ahklog.txt
+            if (x > halfw * (1+deadzone))
+            {
+                if(toggle)
+                {
+                    Send, {d down}
+                }
+                else
+                {
+                    send, {d up}
+                }
+            } 
+            else
+            {
+                send, {d up}
+            }
+            if (y < halfh*(1-deadzone))
+            {
+                if(toggle)
+                {
+                    Send, {w down}
+                }
+                else
+                {
+                    send, {w up}
+                }		
+            } 	
+            else
+            {
+                send, {w up}
+            }
+            if (x < halfw * (1-deadzone))
+            {
+                if(toggle)
+                {
+                    Send, {a down}
+                }
+                else
+                {
+                    send, {a up}
+                }		
+            } 
+            else
+            {
+                send, {a up}
+            }
+            if (y > halfh*(1+deadzone))
+            {
+                if(toggle)
+                {
+                    Send, {s down}
+                }
+                else
+                {
+                    send, {s up}
+                }		
+            } 	
+            else
+            {
+                send, {s up}
+            }
+        }
     }
-  }
-  else
-  {
-    GoSub, Run
-  }
-	; FileAppend, finished`n, ahklog.txt
-	return
+
+    #ifWinActive, Factorio
+        ~RButton Up::
+            toggle := !toggle
+            state := GetKeyState("RButton", "D")
+            ; FileAppend, class: %class% state: %state%`n, ahklog.txt
+            if (toggle)
+            {
+                while toggle
+                {
+                    GoSub, Run
+                    sleep, 100
+                }
+            }
+            else
+            {
+                GoSub, Run
+            }
+            ; FileAppend, finished`n, ahklog.txt
+        return
+        #ifWinActive, Factorio
+        ~LButton Up::
+            toggle := 0
+            GoSub, Run


### PR DESCRIPTION
Hello. I would understand if you wouldn't want to merge this because it's a big change from your original script. What I've done is made it so that you only need to press right click to move toward the mouse. Clicking again (or pressing any key) will interrupt movement. 

I personally find this more ergonomic because I no longer have to hold RMB down to move. 